### PR TITLE
Android Use ACCESS_FINE_LOCATION instead of COARSE for bluetooth access

### DIFF
--- a/extras/Projucer/Source/ProjectSaving/jucer_ProjectExport_Android.h
+++ b/extras/Projucer/Source/ProjectSaving/jucer_ProjectExport_Android.h
@@ -1834,7 +1834,7 @@ private:
         {
             s.add ("android.permission.BLUETOOTH");
             s.add ("android.permission.BLUETOOTH_ADMIN");
-            s.add ("android.permission.ACCESS_COARSE_LOCATION");
+            s.add ("android.permission.ACCESS_FINE_LOCATION");
         }
 
         if (androidExternalReadPermission.get())

--- a/modules/juce_core/native/juce_android_RuntimePermissions.cpp
+++ b/modules/juce_core/native/juce_android_RuntimePermissions.cpp
@@ -29,7 +29,7 @@ static String jucePermissionToAndroidPermission (RuntimePermissions::PermissionI
     switch (permission)
     {
         case RuntimePermissions::recordAudio:            return "android.permission.RECORD_AUDIO";
-        case RuntimePermissions::bluetoothMidi:          return "android.permission.ACCESS_COARSE_LOCATION";
+        case RuntimePermissions::bluetoothMidi:          return "android.permission.ACCESS_FINE_LOCATION";
         case RuntimePermissions::readExternalStorage:    return "android.permission.READ_EXTERNAL_STORAGE";
         case RuntimePermissions::writeExternalStorage:   return "android.permission.WRITE_EXTERNAL_STORAGE";
         case RuntimePermissions::camera:                 return "android.permission.CAMERA";
@@ -43,7 +43,7 @@ static String jucePermissionToAndroidPermission (RuntimePermissions::PermissionI
 static RuntimePermissions::PermissionID androidPermissionToJucePermission (const String& permission)
 {
     if      (permission == "android.permission.RECORD_AUDIO")             return RuntimePermissions::recordAudio;
-    else if (permission == "android.permission.ACCESS_COARSE_LOCATION")   return RuntimePermissions::bluetoothMidi;
+    else if (permission == "android.permission.ACCESS_FINE_LOCATION")   return RuntimePermissions::bluetoothMidi;
     else if (permission == "android.permission.READ_EXTERNAL_STORAGE")    return RuntimePermissions::readExternalStorage;
     else if (permission == "android.permission.WRITE_EXTERNAL_STORAGE")   return RuntimePermissions::writeExternalStorage;
     else if (permission == "android.permission.CAMERA")                   return RuntimePermissions::camera;


### PR DESCRIPTION
Needed for Android 10 devices with SDK 29+